### PR TITLE
Bump version to 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+## 0.11.0 (2026-03-09)
+
+- [#35](https://github.com/codeocean/codeocean-mcp-server/pull/35) feat: add `delete_computation` tool to stop and delete computations
+
 ## 0.10.0 (2026-02-24)
 
 - [#33](https://github.com/codeocean/codeocean-mcp-server/pull/33) feat: upgrade mcp package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codeocean-mcp-server"
-version = "0.10.0"
+version = "0.11.0"
 authors = [{ name = "Code Ocean", email = "dev@codeocean.com" }]
 description = "Code Ocean MCP Server"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Bump version from 0.10.0 to 0.11.0
- Update CHANGELOG with `delete_computation` tool addition (#35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)