### PR TITLE
feat: serve over streamable HTTP with per-request credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This MCP server provides tools to search and run capsules and pipelines, and man
     - [Roo Code](#roo-code)
     - [Cursor](#cursor)
     - [Windsurf](#windsurf)
+- [Streamable HTTP Transport](#streamable-http-transport)
 - [Local Testing](#local-testing)
 
 ## Prerequisites
@@ -196,6 +197,19 @@ Windsurf (Cascade) uses mcp_config.json under ~/.codeium/windsurf/ (or via the C
 ```
 
 3.	Save and restart Windsurf (or hit “Refresh” in the MCP panel).
+
+## Streamable HTTP Transport
+
+By default the server runs over stdio and authenticates with the `CODEOCEAN_TOKEN` environment variable, as
+described above. It can also serve multiple users from a single process over streamable HTTP, taking each
+caller's API token from the request instead:
+
+```bash
+CODEOCEAN_DOMAIN=https://acmecorp.codeocean.com codeocean-mcp-server --transport streamable-http --host 127.0.0.1 --port 8000
+```
+
+Clients then pass their own token as `Authorization: Bearer <YOUR_API_KEY>` on every request; `CODEOCEAN_TOKEN`
+is not used, and a request without a token is refused. The endpoint is `http://<host>:<port>/mcp`.
 
 ## Local Testing
 

--- a/src/codeocean_mcp_server/client.py
+++ b/src/codeocean_mcp_server/client.py
@@ -1,0 +1,50 @@
+"""Per-request Code Ocean client resolution for the streamable-HTTP transport."""
+
+from functools import lru_cache
+
+from codeocean import CodeOcean
+from mcp.server.fastmcp import FastMCP
+from starlette.requests import Request
+
+
+@lru_cache(maxsize=32)
+def _cached_client(domain: str, token: str, agent_id: str | None) -> CodeOcean:
+    """Return a client for the given credentials, reusing its HTTP connection pool across requests."""
+    return CodeOcean(domain=domain, token=token, agent_id=agent_id)
+
+
+def _bearer_token(request: Request) -> str | None:
+    scheme, _, token = request.headers.get("authorization", "").partition(" ")
+    return token.strip() or None if scheme.lower() == "bearer" else None
+
+
+class RequestScopedClient:
+    """A `CodeOcean` stand-in that resolves to the calling request's own client on every attribute access.
+
+    Tools reach the SDK as `client.<sub_client>.<method>(...)`, evaluated when the tool runs, so wrapping
+    the client is enough to give each request its own credentials without touching the tools themselves.
+
+    Outside a request — tool registration, where descriptions are read from SDK docstrings — attribute
+    access resolves to `placeholder`, which issues no network call.
+    """
+
+    def __init__(self, mcp: FastMCP, domain: str, agent_id: str | None, placeholder: CodeOcean):
+        """Wrap the credentials that are fixed for the process, around the token that varies per request."""
+        self._mcp = mcp
+        self._domain = domain
+        self._agent_id = agent_id
+        self._placeholder = placeholder
+
+    def __getattr__(self, name: str):
+        """Delegate to the calling request's client."""
+        return getattr(self._resolve(), name)
+
+    def _resolve(self) -> CodeOcean:
+        try:
+            request = self._mcp.get_context().request_context.request
+        except ValueError:
+            return self._placeholder
+        token = _bearer_token(request) if request is not None else None
+        if not token:
+            raise ValueError("Missing Code Ocean API token: send it as an 'Authorization: Bearer <token>' header.")
+        return _cached_client(self._domain, token, self._agent_id)

--- a/src/codeocean_mcp_server/client.py
+++ b/src/codeocean_mcp_server/client.py
@@ -14,8 +14,11 @@ def _cached_client(domain: str, token: str, agent_id: str | None) -> CodeOcean:
 
 
 def _bearer_token(request: Request) -> str | None:
+    """Return the token from an 'Authorization: Bearer <token>' header, or None for any other scheme."""
     scheme, _, token = request.headers.get("authorization", "").partition(" ")
-    return token.strip() or None if scheme.lower() == "bearer" else None
+    if scheme.lower() != "bearer":
+        return None
+    return token.strip() or None
 
 
 class RequestScopedClient:

--- a/src/codeocean_mcp_server/client.py
+++ b/src/codeocean_mcp_server/client.py
@@ -28,15 +28,15 @@ class RequestScopedClient:
     the client is enough to give each request its own credentials without touching the tools themselves.
 
     Outside a request — tool registration, where descriptions are read from SDK docstrings — attribute
-    access resolves to `placeholder`, which issues no network call.
+    access resolves to a client built from the environment's token, which issues no network call.
     """
 
-    def __init__(self, mcp: FastMCP, domain: str, agent_id: str | None, placeholder: CodeOcean):
+    def __init__(self, mcp: FastMCP, domain: str, token: str | None, agent_id: str | None):
         """Wrap the credentials that are fixed for the process, around the token that varies per request."""
         self._mcp = mcp
         self._domain = domain
+        self._token = token
         self._agent_id = agent_id
-        self._placeholder = placeholder
 
     def __getattr__(self, name: str):
         """Delegate to the calling request's client."""
@@ -46,7 +46,8 @@ class RequestScopedClient:
         try:
             request = self._mcp.get_context().request_context.request
         except ValueError:
-            return self._placeholder
+            # Registration happens outside any request, so it needs no credential of its own.
+            return _cached_client(self._domain, self._token or "", self._agent_id)
         token = _bearer_token(request) if request is not None else None
         if not token:
             raise ValueError("Missing Code Ocean API token: send it as an 'Authorization: Bearer <token>' header.")

--- a/src/codeocean_mcp_server/server.py
+++ b/src/codeocean_mcp_server/server.py
@@ -1,8 +1,10 @@
+import argparse
 import os
 
 from codeocean import CodeOcean
 from mcp.server.fastmcp import FastMCP
 
+from codeocean_mcp_server.client import RequestScopedClient
 from codeocean_mcp_server.logging_config import configure_logging
 from codeocean_mcp_server.tools import (
     capsules,
@@ -12,29 +14,52 @@ from codeocean_mcp_server.tools import (
 )
 
 
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(prog="codeocean-mcp-server", description="Code Ocean MCP Server")
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "streamable-http"],
+        default="stdio",
+        help="Transport to serve on. Over streamable-HTTP the API token is taken per request from the "
+        "'Authorization: Bearer <token>' header instead of from CODEOCEAN_TOKEN.",
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="Host to bind to when serving over streamable-HTTP.")
+    parser.add_argument("--port", type=int, default=8000, help="Port to bind to when serving over streamable-HTTP.")
+    return parser.parse_args(argv)
+
+
 def main():
     """Run the MCP server."""
     configure_logging()
+    args = parse_args()
+    stdio = args.transport == "stdio"
     domain = os.getenv("CODEOCEAN_DOMAIN")
     token = os.getenv("CODEOCEAN_TOKEN")
-    if not domain or not token:
+    if not domain or (stdio and not token):
         raise ValueError("Environment variables CODEOCEAN_DOMAIN and CODEOCEAN_TOKEN must be set.")
     agent_id = os.getenv("AGENT_ID", "AI Agent")
-    client = CodeOcean(domain=domain, token=token, agent_id=agent_id)
+    env_client = CodeOcean(domain=domain, token=token or "", agent_id=agent_id)
 
     mcp = FastMCP(
         name="Code Ocean",
         instructions=(
             f"MCP server for Code Ocean: search & run capsules, pipelines, and assets using Code Ocean domain {domain}."
         ),
+        host=args.host,
+        port=args.port,
+        stateless_http=True,
     )
+
+    # Over stdio the process serves a single user, so the environment's client is used directly, as before.
+    client = env_client if stdio else RequestScopedClient(mcp, domain, agent_id, placeholder=env_client)
 
     capsules.add_tools(mcp, client)
     data_assets.add_tools(mcp, client)
     computations.add_tools(mcp, client)
     custom_metadata.add_tools(mcp, client)
 
-    mcp.run()
+    mcp.run(transport=args.transport)
 
 
 if __name__ == "__main__":

--- a/src/codeocean_mcp_server/server.py
+++ b/src/codeocean_mcp_server/server.py
@@ -36,8 +36,10 @@ def main():
     stdio = args.transport == "stdio"
     domain = os.getenv("CODEOCEAN_DOMAIN")
     token = os.getenv("CODEOCEAN_TOKEN")
-    if not domain or (stdio and not token):
-        raise ValueError("Environment variables CODEOCEAN_DOMAIN and CODEOCEAN_TOKEN must be set.")
+    if not domain:
+        raise ValueError("Environment variable CODEOCEAN_DOMAIN must be set.")
+    if stdio and not token:
+        raise ValueError("Environment variable CODEOCEAN_TOKEN must be set when serving over stdio.")
     agent_id = os.getenv("AGENT_ID", "AI Agent")
     env_client = CodeOcean(domain=domain, token=token or "", agent_id=agent_id)
 

--- a/src/codeocean_mcp_server/server.py
+++ b/src/codeocean_mcp_server/server.py
@@ -38,10 +38,7 @@ def main():
     token = os.getenv("CODEOCEAN_TOKEN")
     if not domain:
         raise ValueError("Environment variable CODEOCEAN_DOMAIN must be set.")
-    if stdio and not token:
-        raise ValueError("Environment variable CODEOCEAN_TOKEN must be set when serving over stdio.")
     agent_id = os.getenv("AGENT_ID", "AI Agent")
-    env_client = CodeOcean(domain=domain, token=token or "", agent_id=agent_id)
 
     mcp = FastMCP(
         name="Code Ocean",
@@ -53,8 +50,13 @@ def main():
         stateless_http=True,
     )
 
-    # Over stdio the process serves a single user, so the environment's client is used directly, as before.
-    client = env_client if stdio else RequestScopedClient(mcp, domain, agent_id, placeholder=env_client)
+    if stdio:
+        # Over stdio the process serves a single user, so the environment's client is used directly, as before.
+        if not token:
+            raise ValueError("Environment variable CODEOCEAN_TOKEN must be set when serving over stdio.")
+        client = CodeOcean(domain=domain, token=token, agent_id=agent_id)
+    else:
+        client = RequestScopedClient(mcp, domain, token, agent_id)
 
     capsules.add_tools(mcp, client)
     data_assets.add_tools(mcp, client)

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -87,8 +87,8 @@ def _stdio_server(domain: str) -> StdioServerParameters:
     )
 
 
-async def _call_get_custom_metadata(url: str, token: str | None):
-    headers = {"Authorization": f"Bearer {token}"} if token else None
+async def _call_get_custom_metadata(url: str, token: str | None, scheme: str = "Bearer"):
+    headers = {"Authorization": f"{scheme} {token}"} if token else None
     async with streamablehttp_client(url, headers=headers) as (read_stream, write_stream, _):
         async with ClientSession(read_stream, write_stream) as session:
             await session.initialize()
@@ -114,6 +114,14 @@ def test_request_without_credential_is_refused(http_server):
     """A request carrying no token is refused rather than served with the environment's client."""
     url, _ = http_server
     result = asyncio.run(_call_get_custom_metadata(url, None))
+    assert result.isError
+    assert "Missing Code Ocean API token" in result.content[0].text
+
+
+def test_non_bearer_credential_is_refused(http_server):
+    """A token offered under any scheme other than Bearer is refused rather than used."""
+    url, _ = http_server
+    result = asyncio.run(_call_get_custom_metadata(url, "alice-token", scheme="Basic"))
     assert result.isError
     assert "Missing Code Ocean API token" in result.content[0].text
 

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -1,0 +1,132 @@
+"""End-to-end tests for the streamable-HTTP transport and its per-request credentials.
+
+A stub Code Ocean API echoes back the token it was called with, so each assertion follows a token
+from the MCP request header all the way to the outgoing API call.
+"""
+
+import asyncio
+import base64
+import json
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.streamable_http import streamablehttp_client
+from mcp_client import get_tools
+
+SERVER_SCRIPT_PATH = str(Path(__file__).parent.parent / "src" / "codeocean_mcp_server" / "server.py")
+
+
+class _EchoTokenHandler(BaseHTTPRequestHandler):
+    """Answer the custom metadata endpoint with the basic-auth user, which is the API token."""
+
+    def do_GET(self):  # noqa: D102, N802
+        user = base64.b64decode(self.headers["Authorization"].split(" ")[1]).decode().split(":")[0]
+        body = json.dumps({"categories": [user]}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):  # noqa: D102
+        pass
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _wait_until_listening(port: int, timeout: float = 30.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with socket.socket() as sock:
+            if sock.connect_ex(("127.0.0.1", port)) == 0:
+                return
+        time.sleep(0.1)
+    raise TimeoutError(f"MCP server did not start listening on port {port}")
+
+
+@pytest.fixture(scope="module")
+def http_server():
+    """Serve the MCP server over streamable-HTTP against a stub Code Ocean API, and yield URL and domain."""
+    api = ThreadingHTTPServer(("127.0.0.1", 0), _EchoTokenHandler)
+    threading.Thread(target=api.serve_forever, daemon=True).start()
+
+    port = _free_port()
+    env = {**os.environ, "CODEOCEAN_DOMAIN": f"http://127.0.0.1:{api.server_address[1]}"}
+    env.pop("CODEOCEAN_TOKEN", None)
+    process = subprocess.Popen(
+        [sys.executable, SERVER_SCRIPT_PATH, "--transport", "streamable-http", "--port", str(port)],
+        env=env,
+    )
+    try:
+        _wait_until_listening(port)
+        yield f"http://127.0.0.1:{port}/mcp", env["CODEOCEAN_DOMAIN"]
+    finally:
+        process.terminate()
+        process.wait(timeout=30)
+        api.shutdown()
+
+
+def _stdio_server(domain: str) -> StdioServerParameters:
+    """Describe the same server run over stdio, against the same Code Ocean domain."""
+    return StdioServerParameters(
+        command=sys.executable,
+        args=[SERVER_SCRIPT_PATH],
+        env={"CODEOCEAN_DOMAIN": domain, "CODEOCEAN_TOKEN": "token"},
+    )
+
+
+async def _call_get_custom_metadata(url: str, token: str | None):
+    headers = {"Authorization": f"Bearer {token}"} if token else None
+    async with streamablehttp_client(url, headers=headers) as (read_stream, write_stream, _):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            return await session.call_tool("get_custom_metadata", {})
+
+
+def test_concurrent_requests_use_their_own_token(http_server):
+    """Each request acts with the token from its own authorization header."""
+    url, _ = http_server
+
+    async def both():
+        return await asyncio.gather(
+            _call_get_custom_metadata(url, "alice-token"),
+            _call_get_custom_metadata(url, "bob-token"),
+        )
+
+    alice, bob = asyncio.run(both())
+    assert alice.structuredContent["categories"] == ["alice-token"]
+    assert bob.structuredContent["categories"] == ["bob-token"]
+
+
+def test_request_without_credential_is_refused(http_server):
+    """A request carrying no token is refused rather than served with the environment's client."""
+    url, _ = http_server
+    result = asyncio.run(_call_get_custom_metadata(url, None))
+    assert result.isError
+    assert "Missing Code Ocean API token" in result.content[0].text
+
+
+def test_tool_definitions_match_stdio(http_server):
+    """Serving over HTTP leaves tool names, schemas and descriptions exactly as stdio serves them."""
+    url, domain = http_server
+
+    async def list_over_http():
+        async with streamablehttp_client(url) as (read_stream, write_stream, _):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                return (await session.list_tools()).tools
+
+    over_stdio = get_tools(_stdio_server(domain))
+    assert [t.model_dump() for t in asyncio.run(list_over_http())] == [t.model_dump() for t in over_stdio]

--- a/uv.lock
+++ b/uv.lock
@@ -558,7 +558,7 @@ wheels = [
 
 [[package]]
 name = "codeocean-mcp-server"
-version = "0.9.1"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "codeocean" },


### PR DESCRIPTION
Lets a single server process serve many users, so callers (notably the Code Ocean agent) can run one shared server instead of spawning one subprocess per invocation.

## Changes

- New `--transport streamable-http` mode (with `--host`/`--port`), served with `stateless_http=True`. `stdio` remains the default; running the server with only `CODEOCEAN_TOKEN` and `CODEOCEAN_DOMAIN` exported from Claude Desktop or Cursor is unchanged.
- The `CodeOcean` client is now resolved per request in HTTP mode, from the request's `Authorization: Bearer` header, via a request-scoped proxy. Tools keep closing over a single `client` object, so all 26 tool definitions, their names, input schemas and descriptions are untouched.
- Tool descriptions are read at registration time, before any request exists; the proxy falls back to a placeholder client built from the environment for those reads, which makes no network call.
- HTTP requests without a usable credential are refused rather than falling back to a server-wide token.
- Per-token clients are cached so connection pools are reused instead of growing with invocation count.