### PR TITLE
fix: apply LOG_FORMAT to uvicorn's own log records

### DIFF
--- a/src/codeocean_mcp_server/logging_config.py
+++ b/src/codeocean_mcp_server/logging_config.py
@@ -3,17 +3,20 @@ import os
 import sys
 
 
-def configure_logging() -> None:
+def configure_logging(transport: str = "stdio") -> None:
     """Configure logging based on LOG_FORMAT environment variable.
 
     If LOG_FORMAT is set, configures the root logger with a StreamHandler
-    using the specified format string, and applies the same format to the
-    loggers uvicorn serves the streamable-HTTP transport with. This must be
-    called before FastMCP initialization to ensure our configuration takes
+    using the specified format string, and, for a transport uvicorn serves,
+    applies the same format to uvicorn's own loggers. This must be called
+    before FastMCP initialization to ensure our configuration takes
     precedence.
 
     If LOG_FORMAT is not set or is empty, does nothing and lets FastMCP
     configure logging with its default settings.
+
+    Args:
+        transport: The transport the server is about to serve on.
 
     Environment variables:
         LOG_FORMAT: Python logging format string (optional)
@@ -48,9 +51,13 @@ def configure_logging() -> None:
     logging.root.addHandler(handler)
     logging.root.setLevel(logging.INFO)
 
-    # Over streamable HTTP, uvicorn logs through its own loggers, which it gives handlers that do
-    # not propagate to the root logger. It configures them from this dictionary, which FastMCP
-    # leaves at its default value, so its contents have to be replaced to be reached at all.
+    if transport == "stdio":
+        return
+
+    # Serving over HTTP, uvicorn logs through its own loggers, which it gives handlers that do not
+    # propagate to the root logger. It configures them from this dictionary, which FastMCP leaves
+    # at its default value, so its contents have to be replaced to be reached at all. The import
+    # is local because uvicorn, like in FastMCP itself, is only needed for the transports it serves.
     from uvicorn.config import LOGGING_CONFIG
 
     LOGGING_CONFIG["formatters"]["default"]["fmt"] = log_format

--- a/src/codeocean_mcp_server/logging_config.py
+++ b/src/codeocean_mcp_server/logging_config.py
@@ -7,8 +7,10 @@ def configure_logging() -> None:
     """Configure logging based on LOG_FORMAT environment variable.
 
     If LOG_FORMAT is set, configures the root logger with a StreamHandler
-    using the specified format string. This must be called before FastMCP
-    initialization to ensure our configuration takes precedence.
+    using the specified format string, and applies the same format to the
+    loggers uvicorn serves the streamable-HTTP transport with. This must be
+    called before FastMCP initialization to ensure our configuration takes
+    precedence.
 
     If LOG_FORMAT is not set or is empty, does nothing and lets FastMCP
     configure logging with its default settings.
@@ -45,3 +47,14 @@ def configure_logging() -> None:
     # This must be done before FastMCP calls logging.basicConfig()
     logging.root.addHandler(handler)
     logging.root.setLevel(logging.INFO)
+
+    # Over streamable HTTP, uvicorn logs through its own loggers, which it gives handlers that do
+    # not propagate to the root logger. It configures them from this dictionary, which FastMCP
+    # leaves at its default value, so its contents have to be replaced to be reached at all.
+    from uvicorn.config import LOGGING_CONFIG
+
+    LOGGING_CONFIG["formatters"]["default"]["fmt"] = log_format
+    # Access records carry the request in fields of their own rather than in the message.
+    LOGGING_CONFIG["formatters"]["access"]["fmt"] = log_format.replace(
+        "%(message)s", '%(client_addr)s - "%(request_line)s" %(status_code)s'
+    )

--- a/src/codeocean_mcp_server/server.py
+++ b/src/codeocean_mcp_server/server.py
@@ -31,8 +31,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main():
     """Run the MCP server."""
-    configure_logging()
     args = parse_args()
+    configure_logging(args.transport)
     stdio = args.transport == "stdio"
     domain = os.getenv("CODEOCEAN_DOMAIN")
     token = os.getenv("CODEOCEAN_TOKEN")

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,62 @@
+"""End-to-end test for LOG_FORMAT, over the transport that brings a logger of its own along."""
+
+import os
+import re
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+SERVER_SCRIPT_PATH = str(Path(__file__).parent.parent / "src" / "codeocean_mcp_server" / "server.py")
+LOG_FORMAT = "%(asctime)s server %(levelname)s [%(name)s] %(message)s"
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _serve_and_request(port: int) -> str:
+    """Serve over streamable HTTP, make one request, and return everything the server logged."""
+    env = {**os.environ, "CODEOCEAN_DOMAIN": "test-domain", "LOG_FORMAT": LOG_FORMAT}
+    process = subprocess.Popen(
+        [sys.executable, SERVER_SCRIPT_PATH, "--transport", "streamable-http", "--port", str(port)],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            with socket.socket() as sock:
+                if sock.connect_ex(("127.0.0.1", port)) == 0:
+                    break
+            time.sleep(0.1)
+        request = urllib.request.Request(f"http://127.0.0.1:{port}/mcp", data=b"{}")
+        try:
+            urllib.request.urlopen(request)
+        except urllib.error.HTTPError:
+            pass  # The request is rejected; it is logged either way, which is what is under test.
+    finally:
+        process.terminate()
+        process.wait(timeout=30)
+    return process.stdout.read()
+
+
+def test_log_format_applies_to_uvicorns_own_records():
+    """Uvicorn brings its own logging configuration, in whose format these records would be."""
+    log = _serve_and_request(_free_port())
+
+    timestamp = r"^[\d-]{10} [\d:,]+"
+    assert re.search(rf"{timestamp} server INFO \[uvicorn\.error\] Uvicorn running", log, re.MULTILINE)
+    assert re.search(
+        # The status carries its phrase, which only uvicorn's own access formatter puts there.
+        rf'{timestamp} server INFO \[uvicorn\.access\] 127\.0\.0\.1:\d+ - "POST /mcp HTTP/1.1" \d{{3}} [A-Za-z]',
+        log,
+        re.MULTILINE,
+    )

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -20,6 +20,16 @@ def _free_port() -> int:
         return sock.getsockname()[1]
 
 
+def _wait_until_listening(port: int, timeout: float = 30.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with socket.socket() as sock:
+            if sock.connect_ex(("127.0.0.1", port)) == 0:
+                return
+        time.sleep(0.1)
+    raise TimeoutError(f"MCP server did not start listening on port {port}")
+
+
 def _serve_and_request(port: int) -> str:
     """Serve over streamable HTTP, make one request, and return everything the server logged."""
     env = {**os.environ, "CODEOCEAN_DOMAIN": "test-domain", "LOG_FORMAT": LOG_FORMAT}
@@ -31,15 +41,10 @@ def _serve_and_request(port: int) -> str:
         text=True,
     )
     try:
-        deadline = time.monotonic() + 30
-        while time.monotonic() < deadline:
-            with socket.socket() as sock:
-                if sock.connect_ex(("127.0.0.1", port)) == 0:
-                    break
-            time.sleep(0.1)
+        _wait_until_listening(port)
         request = urllib.request.Request(f"http://127.0.0.1:{port}/mcp", data=b"{}")
         try:
-            urllib.request.urlopen(request)
+            urllib.request.urlopen(request, timeout=30)
         except urllib.error.HTTPError:
             pass  # The request is rejected; it is logged either way, which is what is under test.
     finally:
@@ -55,8 +60,9 @@ def test_log_format_applies_to_uvicorns_own_records():
     timestamp = r"^[\d-]{10} [\d:,]+"
     assert re.search(rf"{timestamp} server INFO \[uvicorn\.error\] Uvicorn running", log, re.MULTILINE)
     assert re.search(
-        # The status carries its phrase, which only uvicorn's own access formatter puts there.
-        rf'{timestamp} server INFO \[uvicorn\.access\] 127\.0\.0\.1:\d+ - "POST /mcp HTTP/1.1" \d{{3}} [A-Za-z]',
+        # The status runs to the end of the line as code and phrase, which only uvicorn's own
+        # access formatter puts there; the raw record carries the code alone.
+        rf'{timestamp} server INFO \[uvicorn\.access\] 127\.0\.0\.1:\d+ - "POST /mcp HTTP/1.1" \d{{3}} \w+( \w+)*$',
         log,
         re.MULTILINE,
     )


### PR DESCRIPTION
`LOG_FORMAT` configures the root logger, which covers every record the server emits over stdio. Over streamable HTTP it misses uvicorn's own records — startup lines and the access log — because uvicorn configures `uvicorn`, `uvicorn.error` and `uvicorn.access` from a logging dictionary of its own and gives them handlers that do not propagate to the root logger. Those records come out in uvicorn's default format, alongside the host application's format:

```
2026-08-28 09:05:44,128 agent INFO [agent.mcp_server] Started Code Ocean MCP server
INFO:     Started server process [26]
INFO:     Uvicorn running on http://127.0.0.1:8126 (Press CTRL+C to quit)
INFO:     127.0.0.1:33876 - "POST /mcp HTTP/1.1" 200 OK
```

`configure_logging` now applies `LOG_FORMAT` to that dictionary as well, so uvicorn's records are formatted like the rest. Access records keep the request fields uvicorn's access formatter fills in, including the status phrase. Nothing changes when `LOG_FORMAT` is unset, or over stdio, where uvicorn never runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)