### PR TITLE
Bump version to 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+## 0.12.1 (2026-08-28)
+
+- [#40](https://github.com/codeocean/codeocean-mcp-server/pull/40) fix: apply `LOG_FORMAT` to uvicorn's own log records
+
 ## 0.12.0 (2026-08-27)
 
 - [#38](https://github.com/codeocean/codeocean-mcp-server/pull/38) feat: serve over streamable HTTP with per-request credentials

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codeocean-mcp-server"
-version = "0.12.0"
+version = "0.12.1"
 authors = [{ name = "Code Ocean", email = "dev@codeocean.com" }]
 description = "Code Ocean MCP Server"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -558,7 +558,7 @@ wheels = [
 
 [[package]]
 name = "codeocean-mcp-server"
-version = "0.12.0"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "codeocean" },


### PR DESCRIPTION
Release 0.12.1

Contains [#40](https://github.com/codeocean/codeocean-mcp-server/pull/40): `LOG_FORMAT` now applies to uvicorn's own startup and access records when serving over streamable HTTP, so a host application's log format covers everything the server emits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)